### PR TITLE
Xenial support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # homer-puppet
 #### HOMER Puppet Modules
 
-This is a Puppet module to install and configure [Homer](https://github.com/sipcapture/homer)
+This is a Puppet module to install and configure [Homer](https://github.com/sipcapture/homer).
 
 Define a structure like this:
 
@@ -90,7 +90,7 @@ git clone https://github.com/sipcapture/homer-puppet
 cd homer-puppet
 ```
 
-# If needed, use the appropriate branch, e.g.:
+If needed, use the appropriate branch, e.g.:
 #git checkout gv/xenial
 
 ```
@@ -116,9 +116,9 @@ Dependencies
 Tested on
 ---------
 
-Ubuntu 16.04
-Ubuntu 14.04
-Debian 8.3
+- Ubuntu 16.04
+- Ubuntu 14.04
+- Debian 8.3
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ git clone https://github.com/sipcapture/homer-puppet
 cd homer-puppet
 ```
 
-If needed, use the appropriate branch, e.g.:
-#git checkout gv/xenial
+If needed, use the appropriate branch, e.g. `git checkout gv/xenial`.
+
+Run the Puppet deployment:
 
 ```
 puppet apply --debug --modulepath=/etc/puppet/modules:modules/ site.pp --show_diff

--- a/README.md
+++ b/README.md
@@ -59,6 +59,70 @@ sudo puppet apply --debug --modulepath=/etc/puppet/modules:modules/ site.pp --sh
 sudo puppet apply --debug --modulepath=/etc/puppet/modules:modules/ site.pp --show_diff
 ```
 
+Summary of installation procedure
+---------------------------------
+
+```
+apt update
+apt install -y git wget
+
+# Puppet for debian jessie
+#wget https://apt.puppetlabs.com/puppetlabs-release-jessie.deb
+#dpkg -i puppetlabs-release-jessie.deb
+
+# Puppet for ubuntu xenial
+wget https://apt.puppetlabs.com/puppetlabs-release-pc1-xenial.deb
+dpkg -i puppetlabs-release-pc1-xenial.deb
+
+apt update
+apt install -y puppet
+
+# Required Puppet modules (mysql is optional)
+puppet module install puppetlabs/stdlib && puppet module install puppetlabs/mysql && puppet module install puppetlabs/apt
+
+# The "source dir" by default is '/root'
+# It can be changed by setting 'source_dir => DIR,' in site.pp
+# This is where the module expects the source code for homer-ui and homer-api
+cd /root
+git clone https://github.com/sipcapture/homer-ui
+git clone https://github.com/sipcapture/homer-api
+git clone https://github.com/sipcapture/homer-puppet
+cd homer-puppet
+```
+
+# If needed
+#git checkout gv/xenial
+
+```
+puppet apply --debug --modulepath=/etc/puppet/modules:modules/ site.pp --show_diff
+```
+
+```
+/usr/local/sbin/kamailio -f /usr/local/etc/kamailio/kamailio.cfg -E -e
+```
+
+
+Installing Kamailio from source
+-------------------------------
+
+```
+apt update
+apt install -y make gcc bison flex libmysqlclient-dev
+mkdir -p /usr/local/src/kamailio-4.4
+cd /usr/local/src/kamailio-4.4
+git clone --depth 1 --no-single-branch git://git.kamailio.org/kamailio kamailio
+cd kamailio
+git checkout -b 4.4 origin/4.4
+
+make FLAVOUR=kamailio include_modules="db_mysql" cfg && make all && make install
+```
+
+(run puppet apply)
+
+```
+/usr/local/sbin/kamailio -f /usr/local/etc/kamailio/kamailio.cfg -E -e
+```
+
 Dependencies
 ------------
 
@@ -71,8 +135,8 @@ Dependencies
 Tested on
 ---------
 
+Ubuntu 16.04
 Ubuntu 14.04
-
 Debian 8.3
 
 License

--- a/README.md
+++ b/README.md
@@ -90,38 +90,19 @@ git clone https://github.com/sipcapture/homer-puppet
 cd homer-puppet
 ```
 
-# If needed
+# If needed, use the appropriate branch, e.g.:
 #git checkout gv/xenial
 
 ```
 puppet apply --debug --modulepath=/etc/puppet/modules:modules/ site.pp --show_diff
 ```
 
-```
-/usr/local/sbin/kamailio -f /usr/local/etc/kamailio/kamailio.cfg -E -e
-```
-
-
-Installing Kamailio from source
--------------------------------
+Ensure kamailio is running and watched by monit:
 
 ```
-apt update
-apt install -y make gcc bison flex libmysqlclient-dev
-mkdir -p /usr/local/src/kamailio-4.4
-cd /usr/local/src/kamailio-4.4
-git clone --depth 1 --no-single-branch git://git.kamailio.org/kamailio kamailio
-cd kamailio
-git checkout -b 4.4 origin/4.4
-
-make FLAVOUR=kamailio include_modules="db_mysql" cfg && make all && make install
+monit start kamailio
 ```
 
-(run puppet apply)
-
-```
-/usr/local/sbin/kamailio -f /usr/local/etc/kamailio/kamailio.cfg -E -e
-```
 
 Dependencies
 ------------

--- a/modules/homer/files/kamailio/kamctlrc
+++ b/modules/homer/files/kamailio/kamctlrc
@@ -124,7 +124,7 @@
 CTLENGINE="FIFO"
 
 ## path to FIFO file
-FIFOPATH="/tmp/kamailio_fifo"
+# FIFOPATH="/var/run/kamailio/kamailio_fifo"
 
 ## check ACL names; default on (1); off (0)
 # VERIFY_ACL=1

--- a/modules/homer/files/kamailio/monit_conf
+++ b/modules/homer/files/kamailio/monit_conf
@@ -1,0 +1,4 @@
+check process kamailio with pidfile /var/run/kamailio/kamailio.pid
+    start program = "/etc/init.d/kamailio start"
+    stop  program = "/etc/init.d/kamailio stop"
+    if 5 restarts within 5 cycles then timeout

--- a/modules/homer/files/mysql/homer_mysql_rotate.pl
+++ b/modules/homer/files/mysql/homer_mysql_rotate.pl
@@ -150,7 +150,7 @@ foreach my $table (keys %{ $CONFIG->{"DATA_TABLE_ROTATION"} }) {
         my $sth = $db->prepare($query);
         $sth->execute();
         my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = gmtime(time() - 86400*$rotation_horizon);
-        my $oldest = sprintf("%04d%02d%02d",($year+=1900),(++$mon),$mday,$hour);
+        my $oldest = sprintf("%04d%02d%02d",($year+=1900),(++$mon),$mday);
         $oldest+=0;
         while(my @ref = $sth->fetchrow_array()) {
            my $table_name = $ref[0];
@@ -207,10 +207,14 @@ exit;
 sub db_connect {
     my $CONFIG  = shift;
     my $db_name = shift;
-
-    my $db = DBI->connect("DBI:mysql:".$CONFIG->{"MYSQL"}{$db_name}.":".$CONFIG->{"MYSQL"}{"host"}.":".$CONFIG->{"MYSQL"}{"port"}, $CONFIG->{"MYSQL"}{"user"}, $CONFIG->{"MYSQL"}{"password"});
+    my $dbistring = "";
+    if($CONFIG->{"MYSQL"}{"usesocket"}) {
+    	$dbistring = "DBI:mysql:database=".$CONFIG->{"MYSQL"}{$db_name}.";mysql_socket=".$CONFIG->{"MYSQL"}{"socket"}
+    } else {
+    	$dbistring = "DBI:mysql:".$CONFIG->{"MYSQL"}{$db_name}.":".$CONFIG->{"MYSQL"}{"host"}.":".$CONFIG->{"MYSQL"}{"port"}
+    }
+    my $db = DBI->connect($dbistring, $CONFIG->{"MYSQL"}{"user"}, $CONFIG->{"MYSQL"}{"password"});
     return $db;
-
 }
 
 sub calculate_gmt_offset {

--- a/modules/homer/manifests/init.pp
+++ b/modules/homer/manifests/init.pp
@@ -125,7 +125,7 @@ class homer(
 ) inherits homer::params {
     validate_bool($manage_mysql)
 
-    if $ui_admin_password == undef {
+    if ($manage_mysql and ($ui_admin_password == undef)) {
         fail('You must define ui_admin_password')
     }
 
@@ -145,17 +145,17 @@ class homer(
         class { 'homer::mysql':
             mysql_root_password => $mysql_root_password,
             stage               => 'preconditions',
+        } ->
+        class { 'homer::mysql::scripts':
+            base_dir            => $base_dir,
+            mysql_host          => $mysql_host,
+            mysql_user          => $mysql_user,
+            mysql_password      => $mysql_password,
+            mysql_root_password => $mysql_root_password,
+            ui_admin_password   => $ui_admin_password,
         }
     }
 
-    class { 'homer::mysql::scripts':
-        base_dir            => $base_dir,
-        mysql_host          => $mysql_host,
-        mysql_user          => $mysql_user,
-        mysql_password      => $mysql_password,
-        mysql_root_password => $mysql_root_password,
-        ui_admin_password   => $ui_admin_password,
-    } ->
     class { 'homer::web':
         base_dir       => $base_dir,
         mysql_user     => $mysql_user,

--- a/modules/homer/manifests/init.pp
+++ b/modules/homer/manifests/init.pp
@@ -106,6 +106,9 @@
 #
 class homer(
     $base_dir            = $homer::params::base_dir,
+    $db_configuration    = $homer::params::db_configuration,
+    $db_data             = $homer::params::db_data,
+    $db_statistic        = $homer::params::db_statistic,
     $listen_if           = $homer::params::listen_if,
     $listen_port         = $homer::params::listen_port,
     $listen_proto        = $homer::params::listen_proto,
@@ -156,7 +159,15 @@ class homer(
         }
     }
 
+    class { 'homer::mysql::rotation':
+        base_dir       => $base_dir,
+        mysql_host     => $mysql_host,
+        mysql_user     => $mysql_user,
+        mysql_password => $mysql_password,
+    }
+
     class { 'homer::web':
+        db_configuration => $db_configuration,
         base_dir       => $base_dir,
         mysql_user     => $mysql_user,
         mysql_password => $mysql_password,
@@ -171,6 +182,8 @@ class homer(
         web_user         => $web_user,
     } ->
     class { 'homer::kamailio':
+        db_data          => $db_data,
+        db_statistic     => $db_statistic,
         listen_proto     => $listen_proto,
         listen_if        => $listen_if,
         listen_port      => $listen_port,

--- a/modules/homer/manifests/kamailio.pp
+++ b/modules/homer/manifests/kamailio.pp
@@ -32,27 +32,38 @@ class homer::kamailio(
     case $::lsbdistcodename {
         'trusty': {
             include 'homer::kamailio::apt'
+            $manage_kamailio_package = true
          }
         'precise': {
             include 'homer::kamailio::apt'
+            $manage_kamailio_package = true
          }
         'jessie': {
             include 'homer::kamailio::apt'
+            $manage_kamailio_package = true
          }
         'wheezy': {
             include 'homer::kamailio::apt'
+            $manage_kamailio_package = true
          }
         'squeeze': {
             include 'homer::kamailio::apt'
+            $manage_kamailio_package = true
          }
+        'xenial': {
+            $manage_kamailio_package = false
+        }
     }
 
-    package { ['kamailio',
+    if ($manage_kamailio_package) {
+        package { ['kamailio',
                'kamailio-geoip-modules',
                'kamailio-utils-modules',
                'kamailio-mysql-modules']:
-        ensure => present,
-    } ->
+            ensure => present,
+        }
+    }
+
     file { $kamailio_etc_dir:
         ensure => directory,
     } ->

--- a/modules/homer/manifests/kamailio.pp
+++ b/modules/homer/manifests/kamailio.pp
@@ -39,6 +39,8 @@ class homer::kamailio(
 
     $manage_systemd = false
 
+    include 'homer::kamailio::monit'
+
     case $::lsbdistcodename {
         'trusty': {
             include 'homer::kamailio::apt'

--- a/modules/homer/manifests/kamailio.pp
+++ b/modules/homer/manifests/kamailio.pp
@@ -19,6 +19,8 @@
 #
 ## homer::kamailio
 class homer::kamailio(
+    $db_data,
+    $db_statistic,
     $listen_proto,
     $listen_if,
     $listen_port,

--- a/modules/homer/manifests/kamailio.pp
+++ b/modules/homer/manifests/kamailio.pp
@@ -27,18 +27,24 @@ class homer::kamailio(
     $mysql_user,
     $mysql_password,
 ) {
+    $manage_systemd = false
 
-    # TODO: refine this conditional
-    case $::operatingsystem {
-        'Ubuntu': {
+    case $::lsbdistcodename {
+        'trusty': {
             include 'homer::kamailio::apt'
-            $manage_systemd = false
          }
-        'Debian': {
+        'precise': {
             include 'homer::kamailio::apt'
-            $manage_systemd = false
          }
-        default : { $manage_systemd = true }
+        'jessie': {
+            include 'homer::kamailio::apt'
+         }
+        'wheezy': {
+            include 'homer::kamailio::apt'
+         }
+        'squeeze': {
+            include 'homer::kamailio::apt'
+         }
     }
 
     package { ['kamailio',

--- a/modules/homer/manifests/kamailio.pp
+++ b/modules/homer/manifests/kamailio.pp
@@ -27,6 +27,14 @@ class homer::kamailio(
     $mysql_user,
     $mysql_password,
 ) {
+    group { 'kamailio':
+        ensure => present,
+    } ->
+    user { 'kamailio':
+        name => 'kamailio',
+        gid  => 'kamailio',
+    }
+
     $manage_systemd = false
 
     case $::lsbdistcodename {
@@ -72,26 +80,22 @@ class homer::kamailio(
         owner   => 'kamailio',
         group   => 'kamailio',
         content => file('homer/kamailio/kamailio.cfg'),
-        notify  => Service['kamailio'],
     } ->
     file { "${kamailio_etc_dir}/kamailio-local.cfg":
         ensure  => present,
         owner   => 'kamailio',
         group   => 'kamailio',
         content => template('homer/kamailio/kamailio-local.cfg.erb'),
-        notify  => Service['kamailio'],
     } ->
     file { "${kamailio_etc_dir}/kamctlrc":
         ensure  => present,
         owner   => 'kamailio',
         group   => 'kamailio',
         content => file('homer/kamailio/kamctlrc'),
-        notify  => Service['kamailio'],
     } ->
     file { '/etc/default/kamailio':
         ensure  => present,
         content => file('homer/kamailio/default'),
-        notify  => Service['kamailio'],
     }
 
     if ($manage_systemd) {
@@ -119,10 +123,10 @@ class homer::kamailio(
             path        => '/bin',
             refreshonly => true,
         }
-    }
 
-    service { 'kamailio':
-        ensure => running,
-        enable => true,
+        service { 'kamailio':
+            ensure => running,
+            enable => true,
+        }
     }
 }

--- a/modules/homer/manifests/kamailio.pp
+++ b/modules/homer/manifests/kamailio.pp
@@ -61,7 +61,8 @@ class homer::kamailio(
             $manage_kamailio_package = true
          }
         'xenial': {
-            $manage_kamailio_package = false
+            include 'homer::kamailio::apt'
+            $manage_kamailio_package = true
         }
     }
 

--- a/modules/homer/manifests/kamailio/apt.pp
+++ b/modules/homer/manifests/kamailio/apt.pp
@@ -27,14 +27,13 @@ class homer::kamailio::apt(
         ensure => present,
     }
 
+    exec { 'install_apt_key':
+        command => '/usr/bin/apt-key adv --keyserver http://deb.kamailio.org/kamailiodebkey.gpg --recv-keys E79ACECB87D8DCD23A20AD2FFB40D3E6508EA4C8',
+    } ->
     apt::source { "kamailio_${::lsbdistcodename}":
         location          => 'http://deb.kamailio.org/kamailio44',
         release           => $::lsbdistcodename,
         repos             => 'main',
-        key               => {
-            id     => 'E79ACECB87D8DCD23A20AD2FFB40D3E6508EA4C8',
-            server => 'deb.kamailio.org',
-        },
         include           => {
             src => true,
         },

--- a/modules/homer/manifests/kamailio/apt.pp
+++ b/modules/homer/manifests/kamailio/apt.pp
@@ -33,7 +33,7 @@ class homer::kamailio::apt(
         repos             => 'main',
         key               => {
             id     => 'E79ACECB87D8DCD23A20AD2FFB40D3E6508EA4C8',
-            source => 'http://deb.kamailio.org/kamailiodebkey.gpg',
+            server => 'deb.kamailio.org',
         },
         include           => {
             src => true,

--- a/modules/homer/manifests/kamailio/monit.pp
+++ b/modules/homer/manifests/kamailio/monit.pp
@@ -1,0 +1,32 @@
+#
+# Copyright 2016 (C) Giacomo Vacca <giacomo.vacca@gmail.com>
+#
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version
+#
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+#
+# homer::kamailio::monit
+class homer::kamailio::monit() {
+    package { 'monit':
+        ensure => present,
+    } ->
+    file { '/etc/monit/conf-enabled/kamailio':
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => file('homer/kamailio/monit_conf'),
+    }
+}

--- a/modules/homer/manifests/mysql/rotation.pp
+++ b/modules/homer/manifests/mysql/rotation.pp
@@ -18,14 +18,12 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 #
-# class homer::mysql::scripts
-class homer::mysql::scripts(
+# class homer::mysql::rotation
+class homer::mysql::rotation(
     $base_dir,
     $mysql_host,
     $mysql_user,
     $mysql_password,
-    $mysql_root_password,
-    $ui_admin_password,
 ) {
     File {
         owner => 'root',
@@ -33,39 +31,37 @@ class homer::mysql::scripts(
         mode  => '0700',
     }
 
+    package { [
+        'perl',
+        'libdbi-perl',
+        'libclass-dbi-mysql-perl'
+        ]:
+        ensure => present,
+    } ->
     file { $base_dir:
         ensure => directory,
     } ->
-    file { "${base_dir}/sql":
-        ensure  => directory,
-        require => File[$base_dir],
-    } ->
-    # Taken from $GIT/homer-api/sql/
-    file { "${base_dir}/sql/schema_data.sql":
+    # These files are taken from homer-api/scripts
+    # From $GIT/homer-api/scripts/rotation.ini
+    file { "${base_dir}/rotation.ini":
         ensure  => file,
-        content => file('homer/mysql/schema_data.sql'),
-        notify  => Exec['run_mysql_setup'],
+        content => template('homer/mysql/rotation.ini.erb'),
     } ->
-    # Taken from $GIT/homer-api/sql/
-    file { "${base_dir}/sql/schema_configuration.sql":
+    # From $GIT/homer-api/scripts/homer_mysql_rotate.pl
+    file { "${base_dir}/homer_mysql_rotate.pl":
         ensure  => file,
-        content => template('homer/mysql/schema_configuration.sql.erb'),
-        notify  => Exec['run_mysql_setup'],
+        content => file('homer/mysql/homer_mysql_rotate.pl'),
     } ->
-    # Taken from $GIT/homer-api/sql/
-    file { "${base_dir}/sql/schema_statistic.sql":
+#N.B. please run rotate.sh manual before send traffic to homer.
+# The script will create capture tables also for current day.
+    # rotate.sh is taken from $GIT/homer-api/scripts/homer_rotate
+    file { "${base_dir}/homer_rotate.sh":
         ensure  => file,
-        content => file('homer/mysql/schema_statistic.sql'),
-        notify  => Exec['run_mysql_setup'],
+        content => template('homer/mysql/homer_rotate.sh.erb'),
     } ->
-    file { "${base_dir}/sql/setup.sql":
+    file { '/etc/cron.d/sipcapture':
         ensure  => file,
-        content => template('homer/mysql/setup.sql.erb'),
-        notify  => Exec['run_mysql_setup'],
-    }
-
-    exec { 'run_mysql_setup':
-        command     => "/usr/bin/mysql -u root -p${mysql_root_password} < ${base_dir}/sql/setup.sql",
-        refreshonly => true,
+        mode    => '0644',
+        content => template('homer/mysql/cron_sipcapture.erb'),
     }
 }

--- a/modules/homer/manifests/mysql/scripts.pp
+++ b/modules/homer/manifests/mysql/scripts.pp
@@ -69,6 +69,13 @@ class homer::mysql::scripts(
         refreshonly => true,
     }
 
+    package { [
+        'perl',
+        'libdbi-perl',
+        'libclass-dbi-mysql-perl'
+        ]:
+        ensure => present,
+    } ->
     # These files are taken from homer-api/scripts
     # From $GIT/homer-api/scripts/rotation.ini
     file { "${base_dir}/rotation.ini":

--- a/modules/homer/manifests/mysql/scripts.pp
+++ b/modules/homer/manifests/mysql/scripts.pp
@@ -33,9 +33,6 @@ class homer::mysql::scripts(
         mode  => '0700',
     }
 
-    file { $base_dir:
-        ensure => directory,
-    } ->
     file { "${base_dir}/sql":
         ensure  => directory,
         require => File[$base_dir],

--- a/modules/homer/manifests/params.pp
+++ b/modules/homer/manifests/params.pp
@@ -33,13 +33,13 @@ class homer::params {
     $web_dir             = '/var/www/sipcapture'
     $web_user            = 'www-data'
     $ui_admin_password   = undef
+    $kamailio_etc_dir    = '/etc/kamailio'
+    $kamailio_mpath      = '/usr/lib/x86_64-linux-gnu/kamailio/modules'
 
     if ($::lsbdistcodename == 'xenial') {
         $db_configuration = 'homer_prod'
         $db_data          = 'homer_prod'
         $db_statistic     = 'homer_prod'
-        $kamailio_mpath   = '/usr/local/lib64/kamailio/modules'
-        $kamailio_etc_dir = '/usr/local/etc/kamailio'
         $phpfpm_socket    = '/var/run/php/php7.0-fpm.sock'
         $php_session_path = '/var/lib/php/session'
         $phpfpm_slowlog   = '/var/log/php/7.0/fpm/www-slow.log'
@@ -49,8 +49,6 @@ class homer::params {
         $db_configuration = 'homer_configuration'
         $db_data          = 'homer_data'
         $db_statistic     = 'homer_statistic'
-        $kamailio_mpath   = '/usr/lib/x86_64-linux-gnu/kamailio/modules'
-        $kamailio_etc_dir = '/etc/kamailio'
         $phpfpm_socker    = '/var/run/php5-fpm.sock'
         $php_session_path = '/var/lib/php5/session'
         $phpfpm_slowlog   = '/var/log/php5-fpm/www-slow.log'

--- a/modules/homer/manifests/params.pp
+++ b/modules/homer/manifests/params.pp
@@ -35,6 +35,9 @@ class homer::params {
     $ui_admin_password   = undef
 
     if ($::lsbdistcodename == 'xenial') {
+        $db_configuration = 'homer_prod'
+        $db_data          = 'homer_prod'
+        $db_statistic     = 'homer_prod'
         $kamailio_mpath   = '/usr/local/lib64/kamailio/modules'
         $kamailio_etc_dir = '/usr/local/etc/kamailio'
         $phpfpm_socket    = '/var/run/php/php7.0-fpm.sock'
@@ -43,7 +46,10 @@ class homer::params {
         $phpfpm_errlog    = '/var/log/php/7.0/fpm/www-error.log'
     }
     else {
-        $kamailio_mpath      = '/usr/lib/x86_64-linux-gnu/kamailio/modules'
+        $db_configuration = 'homer_configuration'
+        $db_data          = 'homer_data'
+        $db_statistic     = 'homer_statistic'
+        $kamailio_mpath   = '/usr/lib/x86_64-linux-gnu/kamailio/modules'
         $kamailio_etc_dir = '/etc/kamailio'
         $phpfpm_socker    = '/var/run/php5-fpm.sock'
         $php_session_path = '/var/lib/php5/session'

--- a/modules/homer/manifests/params.pp
+++ b/modules/homer/manifests/params.pp
@@ -31,10 +31,21 @@ class homer::params {
     $mysql_host          = '127.0.0.1'
     $mysql_password      = undef
     $mysql_root_password = undef
-    $phpfpm_socket       = '/var/run/php5-fpm.sock'
-    $php_session_path    = '/var/lib/php5/session'
     $source_dir          = '/root'
     $web_dir             = '/var/www/sipcapture'
     $web_user            = 'www-data'
     $ui_admin_password   = undef
+
+    if ($::lsbdistcodename == 'xenial') {
+        $phpfpm_socket    = '/var/run/php/php7.0-fpm.sock'
+        $php_session_path = '/var/lib/php/session'
+        $phpfpm_slowlog   = '/var/log/php/7.0/fpm/www-slow.log'
+        $phpfpm_errlog    = '/var/log/php/7.0/fpm/www-error.log'
+    }
+    else {
+        $phpfpm_socker    = '/var/run/php5-fpm.sock'
+        $php_session_path = '/var/lib/php5/session'
+        $phpfpm_slowlog   = '/var/log/php5-fpm/www-slow.log'
+        $phpfpm_errlog    = '/var/log/php5-fpm/www-error.log'
+    }
 }

--- a/modules/homer/manifests/params.pp
+++ b/modules/homer/manifests/params.pp
@@ -24,8 +24,6 @@ class homer::params {
     $listen_if           = '0.0.0.0'
     $listen_port         = '9060'
     $listen_proto        = 'udp'
-    $kamailio_etc_dir    = '/etc/kamailio'
-    $kamailio_mpath      = '/usr/lib/x86_64-linux-gnu/kamailio/modules'
     $manage_mysql        = false
     $mysql_user          = 'sipcapture'
     $mysql_host          = '127.0.0.1'
@@ -37,12 +35,16 @@ class homer::params {
     $ui_admin_password   = undef
 
     if ($::lsbdistcodename == 'xenial') {
+        $kamailio_mpath   = '/usr/local/lib64/kamailio/modules'
+        $kamailio_etc_dir = '/usr/local/etc/kamailio'
         $phpfpm_socket    = '/var/run/php/php7.0-fpm.sock'
         $php_session_path = '/var/lib/php/session'
         $phpfpm_slowlog   = '/var/log/php/7.0/fpm/www-slow.log'
         $phpfpm_errlog    = '/var/log/php/7.0/fpm/www-error.log'
     }
     else {
+        $kamailio_mpath      = '/usr/lib/x86_64-linux-gnu/kamailio/modules'
+        $kamailio_etc_dir = '/etc/kamailio'
         $phpfpm_socker    = '/var/run/php5-fpm.sock'
         $php_session_path = '/var/lib/php5/session'
         $phpfpm_slowlog   = '/var/log/php5-fpm/www-slow.log'

--- a/modules/homer/manifests/params.pp
+++ b/modules/homer/manifests/params.pp
@@ -35,20 +35,17 @@ class homer::params {
     $ui_admin_password   = undef
     $kamailio_etc_dir    = '/etc/kamailio'
     $kamailio_mpath      = '/usr/lib/x86_64-linux-gnu/kamailio/modules'
+    $db_configuration    = 'homer_configuration'
+    $db_data             = 'homer_data'
+    $db_statistic        = 'homer_statistic'
 
     if ($::lsbdistcodename == 'xenial') {
-        $db_configuration = 'homer_prod'
-        $db_data          = 'homer_prod'
-        $db_statistic     = 'homer_prod'
         $phpfpm_socket    = '/var/run/php/php7.0-fpm.sock'
         $php_session_path = '/var/lib/php/session'
         $phpfpm_slowlog   = '/var/log/php/7.0/fpm/www-slow.log'
         $phpfpm_errlog    = '/var/log/php/7.0/fpm/www-error.log'
     }
     else {
-        $db_configuration = 'homer_configuration'
-        $db_data          = 'homer_data'
-        $db_statistic     = 'homer_statistic'
         $phpfpm_socker    = '/var/run/php5-fpm.sock'
         $php_session_path = '/var/lib/php5/session'
         $phpfpm_slowlog   = '/var/log/php5-fpm/www-slow.log'

--- a/modules/homer/manifests/php.pp
+++ b/modules/homer/manifests/php.pp
@@ -24,37 +24,83 @@ class homer::php(
     $php_session_path,
     $web_user,
 ) {
-    package { [
-        'php5-common',
-        'php5-mysql',
-        'php5-fpm'
-        ]:
-        ensure => present,
-    } ->
-    # To store the "PHP sessions"
-    # /var/lib/php is installed by 'php-common'
-    file { $php_session_path:
-        ensure => directory,
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0777',
-    } ->
-    file { '/etc/php5/fpm/pool.d/www.conf':
-        ensure  => present,
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0644',
-        content => template('homer/php/php-fpm-www.conf.erb'),
-        notify  => Service['php5-fpm'],
-    }
 
-    service { 'php5-fpm':
-        ensure => running,
-        enable => true,
-    } ->
-    file { $phpfpm_socket:
-        ensure => present,
-        owner  => $web_user,
-        group  => $web_user,
+    if ($::lsbdistcodename == 'xenial') {
+        $phpfpm_socket    = '/var/run/php/php7.0-fpm.sock'
+        $php_session_path = '/var/lib/php/session'
+        $phpfpm_slowlog   = '/var/log/php/7.0/fpm/www-slow.log'
+        $phpfpm_errlog    = '/var/log/php/7.0/fpm/www-error.log'
+
+        package { [
+            'php-common',
+            'php-mysql',
+            'php-fpm'
+            ]:
+            ensure => present,
+        } ->
+        # To store the "PHP sessions"
+        # /var/lib/php is installed by 'php-common'
+        file { $php_session_path:
+            ensure => directory,
+            owner  => 'root',
+            group  => 'root',
+            mode   => '0777',
+        } ->
+        file { '/etc/php/7.0/fpm/pool.d/www.conf':
+            ensure  => present,
+            owner   => 'root',
+            group   => 'root',
+            mode    => '0644',
+            content => template('homer/php/php-fpm-www.conf.erb'),
+            notify  => Service['php7.0-fpm'],
+        }
+
+        service { 'php7.0-fpm':
+            ensure => running,
+            enable => true,
+        } ->
+        file { $phpfpm_socket:
+            ensure => present,
+            owner  => $web_user,
+            group  => $web_user,
+        }
+    }
+    else {
+        $phpfpm_slowlog   = '/var/log/php5-fpm/www-slow.log'
+        $phpfpm_errlog    = '/var/log/php5-fpm/www-error.log'
+
+        package { [
+            'php5-common',
+            'php5-mysql',
+            'php5-fpm'
+            ]:
+            ensure => present,
+        } ->
+        # To store the "PHP sessions"
+        # /var/lib/php is installed by 'php-common'
+        file { $php_session_path:
+            ensure => directory,
+            owner  => 'root',
+            group  => 'root',
+            mode   => '0777',
+        } ->
+        file { '/etc/php5/fpm/pool.d/www.conf':
+            ensure  => present,
+            owner   => 'root',
+            group   => 'root',
+            mode    => '0644',
+            content => template('homer/php/php-fpm-www.conf.erb'),
+            notify  => Service['php5-fpm'],
+        }
+
+        service { 'php5-fpm':
+            ensure => running,
+            enable => true,
+        } ->
+        file { $phpfpm_socket:
+            ensure => present,
+            owner  => $web_user,
+            group  => $web_user,
+        }
     }
 }

--- a/modules/homer/manifests/php.pp
+++ b/modules/homer/manifests/php.pp
@@ -26,10 +26,6 @@ class homer::php(
 ) {
 
     if ($::lsbdistcodename == 'xenial') {
-        $phpfpm_socket    = '/var/run/php/php7.0-fpm.sock'
-        $php_session_path = '/var/lib/php/session'
-        $phpfpm_slowlog   = '/var/log/php/7.0/fpm/www-slow.log'
-        $phpfpm_errlog    = '/var/log/php/7.0/fpm/www-error.log'
 
         package { [
             'php-common',
@@ -66,8 +62,6 @@ class homer::php(
         }
     }
     else {
-        $phpfpm_slowlog   = '/var/log/php5-fpm/www-slow.log'
-        $phpfpm_errlog    = '/var/log/php5-fpm/www-error.log'
 
         package { [
             'php5-common',

--- a/modules/homer/manifests/web.pp
+++ b/modules/homer/manifests/web.pp
@@ -20,6 +20,7 @@
 #
 # homer::web
 class homer::web(
+    $db_configuration,
     $base_dir,
     $mysql_user,
     $mysql_password,

--- a/modules/homer/metadata.json
+++ b/modules/homer/metadata.json
@@ -12,6 +12,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
+        "16.04",
         "14.04"
       ]
     },

--- a/modules/homer/templates/homer-api/configuration.php.erb
+++ b/modules/homer/templates/homer-api/configuration.php.erb
@@ -9,9 +9,9 @@ define('DB_HOSTNAME', "<%= @mysql_host %>");
 define('DB_PORT', 3306);
 define('DB_USERNAME', "<%= @mysql_user %>");
 define('DB_PASSWORD', "<%= @mysql_password %>");
-define('DB_CONFIGURATION', "homer_configuration");
-define('DB_STATISTIC', "homer_statistic");
-define('DB_HOMER', "homer_data");
+define('DB_CONFIGURATION', "<%= @db_configuration %>");
+define('DB_STATISTIC', "<%= @db_statistic %>");
+define('DB_HOMER', "<%= @db_data %>");
 define('SINGLE_NODE', 1);
 define('DATABASE_DRIVER',"mysql");
 

--- a/modules/homer/templates/kamailio/kamailio-local.cfg.erb
+++ b/modules/homer/templates/kamailio/kamailio-local.cfg.erb
@@ -1,5 +1,5 @@
 #!define HOMER_LISTEN_STRING <%= @listen_proto %>:<%= @listen_if %>:<%= @listen_port %>
-#!define SQLOPS_DBURL "cb=>mysql://<%= @mysql_user %>:<%= @mysql_password %>@<%= @mysql_host %>/homer_statistic"
-#!define SIPCAPTURE_DBURL "mysql://<%= @mysql_user %>:<%= @mysql_password %>@<%= @mysql_host %>/homer_data"
+#!define SQLOPS_DBURL "cb=>mysql://<%= @mysql_user %>:<%= @mysql_password %>@<%= @mysql_host %>/<%= @db_statistic %>"
+#!define SIPCAPTURE_DBURL "mysql://<%= @mysql_user %>:<%= @mysql_password %>@<%= @mysql_host %>/<%= @db_data %>"
 
 #!define MPATH "<%= @kamailio_mpath %>"

--- a/modules/homer/templates/mysql/rotation.ini.erb
+++ b/modules/homer/templates/mysql/rotation.ini.erb
@@ -3,10 +3,10 @@
 [MYSQL]
     user=<%= @mysql_user %>
     password=<%= @mysql_password %>
-    host=localhost
+    host=<%= @mysql_host %>
     port=3306
-    db_data = homer_data
-    db_stats = homer_statistic
+    db_data = <%= @db_data %>
+    db_stats = <%= @db_statistic %>
     # Extra param
     newtables = 2 # Create new tables or partitions for next 2 days
     engine = InnoDB #MyISAM or InnoDB

--- a/modules/homer/templates/php/php-fpm-www.conf.erb
+++ b/modules/homer/templates/php/php-fpm-www.conf.erb
@@ -11,8 +11,8 @@ pm.max_children = 50
 pm.start_servers = 5
 pm.min_spare_servers = 5
 pm.max_spare_servers = 35
-slowlog = /var/log/php5-fpm/www-slow.log
-php_admin_value[error_log] = /var/log/php5-fpm/www-error.log
+slowlog = <%= @phpfpm_slowlog %>
+php_admin_value[error_log] = <%= @phpfpm_errlog %>
 php_admin_flag[log_errors] = on
 php_value[session.save_handler] = files
 php_value[session.save_path] = <%= @php_session_path %>


### PR DESCRIPTION
- Adds support for Ubuntu 16
- Adds monit configuration for kamailio
- DB names can be customized (define `db_configuration`, `db_data` and `db_statistic` in site.pp or hieradata)
- Updates README with complete procedure
- Manages rotation scripts into a separate manifest
- Other minor improvements/fixes

PS: just let me know if you prefer all the commits squashed in one before the merge.